### PR TITLE
Add linux-minidisc

### DIFF
--- a/Formula/linux-minidisc.rb
+++ b/Formula/linux-minidisc.rb
@@ -7,6 +7,7 @@ class LinuxMinidisc < Formula
   head "https://github.com/glaubitz/linux-minidisc.git"
 
   # Dependencies copied from "build/install_dependencies.sh" in the linux-minidisc repo
+  depends_on "pkg-config" => :build
   depends_on "qt5"
   depends_on "mad"
   depends_on "libid3tag"

--- a/Formula/linux-minidisc.rb
+++ b/Formula/linux-minidisc.rb
@@ -1,0 +1,24 @@
+class LinuxMinidisc < Formula
+  desc "Free software for accessing MiniDisc devices"
+  homepage "https://github.com/glaubitz/linux-minidisc"
+  url "https://github.com/glaubitz/linux-minidisc.git", :tag => "0.9.16"
+  version "0.9.16"
+
+  head "https://github.com/glaubitz/linux-minidisc.git"
+
+  # Dependencies copied from "build/install_dependencies.sh" in the linux-minidisc repo
+  depends_on "qt5"
+  depends_on "mad"
+  depends_on "libid3tag"
+  depends_on "libtag"
+  depends_on "glib"
+  depends_on "libusb"
+  depends_on "libusb-compat"
+  depends_on "libgcrypt"
+
+  def install
+    system "qmake"
+    system "make"
+    # TODO: Install produced binaries <https://git.io/fh54E>
+  end
+end

--- a/Formula/linux-minidisc.rb
+++ b/Formula/linux-minidisc.rb
@@ -6,8 +6,9 @@ class LinuxMinidisc < Formula
 
   head "https://github.com/glaubitz/linux-minidisc.git"
 
-  # Dependencies copied from "build/install_dependencies.sh" in the linux-minidisc repo
   depends_on "pkg-config" => :build
+
+  # Dependencies copied from "build/install_dependencies.sh" in the linux-minidisc repo
   depends_on "qt5"
   depends_on "mad"
   depends_on "libid3tag"
@@ -20,6 +21,7 @@ class LinuxMinidisc < Formula
   def install
     system "qmake"
     system "make"
-    # TODO: Install produced binaries <https://git.io/fh54E>
+    system "macdeployqt", "qhimdtransfer/QHiMDTransfer.app"
+    bin.install "himdcli/himdcli", "netmdcli/netmdcli", "qhimdtransfer/QHiMDTransfer.app"
   end
 end


### PR DESCRIPTION
This adds the `linux-minidisc` utilities, `himdcli` and `netmdcli`. It also builds the Qt-based GUI, QHiMDTransfer, and puts it in the package’s `bin` directory.